### PR TITLE
[#13174] Add toggle to hide self responses

### DIFF
--- a/src/web/app/components/question-response-panel/question-response-panel.component.html
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.html
@@ -35,7 +35,7 @@
               <strong>Other responses (to you): </strong>Responses are not visible to you.
             </div>
           </ng-template>
-          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length">
+          <div class="given-responses mt-4" *ngIf="question.responsesFromSelf.length && !hideSelfResponses">
             <strong>Your own responses (to others):</strong>
             <div *ngFor="let responseFromSelf of question.responsesFromSelf">
               <tm-student-view-responses [responses]="[responseFromSelf]" [isSelfResponses]="true" [feedbackQuestion]="question.feedbackQuestion" [timezone]="session.timeZone" [statistics]="question.questionStatistics"></tm-student-view-responses>

--- a/src/web/app/components/question-response-panel/question-response-panel.component.ts
+++ b/src/web/app/components/question-response-panel/question-response-panel.component.ts
@@ -64,6 +64,9 @@ export class QuestionResponsePanelComponent {
   @Input()
   previewAsPerson: string = '';
 
+  @Input()
+  hideSelfResponses: boolean = false;
+
   canUserSeeResponses(question: FeedbackQuestionModel): boolean {
     const showResponsesTo: FeedbackVisibilityType[] = question.feedbackQuestion.showResponsesTo;
     if (this.intent === Intent.STUDENT_RESULT) {

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.html
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.html
@@ -73,6 +73,11 @@
   </div>
 </div>
 
+<div class="form-check form-switch">
+  <input class="form-check-input" type="checkbox" id="hideSelfResponses" [(ngModel)]="hideSelfResponses">
+  <label class="form-check-label" for="hideSelfResponses">Hide your own responses</label>
+</div>
+
 <tm-loading-retry [shouldShowRetry]="hasFeedbackSessionResultsLoadingFailed" [message]="'Failed to load results'" (retryEvent)="retryLoadingFeedbackSessionResults()">
   <div *tmIsLoading="isFeedbackSessionResultsLoading">
     <div *ngIf="questions.length === 0" class="mt-4">
@@ -82,6 +87,7 @@
     </div>
     <tm-question-response-panel [questions]="questions" [session]="session"
                                 [intent]="intent" [regKey]="regKey" [previewAsPerson]="previewAsPerson"
+                                [hideSelfResponses]="hideSelfResponses"
     ></tm-question-response-panel>
   </div>
 </tm-loading-retry>

--- a/src/web/app/pages-session/session-result-page/session-result-page.component.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.component.ts
@@ -106,6 +106,8 @@ export class SessionResultPageComponent implements OnInit {
   feedbackSessionId: string | undefined = '';
   studentId: string | undefined = '';
 
+  hideSelfResponses: boolean = false;
+
   private backendUrl: string = environment.backendUrl;
 
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,

--- a/src/web/app/pages-session/session-result-page/session-result-page.module.ts
+++ b/src/web/app/pages-session/session-result-page/session-result-page.module.ts
@@ -11,6 +11,7 @@ import {
   StudentViewResponsesModule,
 } from '../../components/question-responses/student-view-responses/student-view-responses.module';
 import { QuestionTextWithInfoModule } from '../../components/question-text-with-info/question-text-with-info.module';
+import { FormsModule } from '@angular/forms';
 
 const routes: Routes = [
   {
@@ -25,6 +26,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     CommonModule,
+    FormsModule,
     QuestionTextWithInfoModule,
     StudentViewResponsesModule,
     SingleStatisticsModule,


### PR DESCRIPTION
This PR was created to familiarize myself with the codebase!

**Outline of Solution**

<!-- Give a brief description of how you solved the issue. -->

1. In `session-result-page.component.html`, added a `switch` which binds and toggles the `hideSelfResponses` property in `session-result-page.component.ts`
2. In `question-response-panel.component.ts`, it takes the `hideSelfResponses` property as an input, which is read in the html file

**UI Changes**

<!-- If the solution includes any changes in UI, do also attach screenshots of the new UI. --> 

New toggle to hide self responses:

![image](https://github.com/user-attachments/assets/7087212b-8408-4292-b70a-5cfffbde49be)

Before toggling:

![image](https://github.com/user-attachments/assets/a01eb871-598a-4429-9998-d38192e75982)

After toggling:

![image](https://github.com/user-attachments/assets/2408612a-3732-474c-8403-812f86473520)
